### PR TITLE
Fix minSdkVersion conflict

### DIFF
--- a/libs/xwalk_core_library/xwalk.gradle
+++ b/libs/xwalk_core_library/xwalk.gradle
@@ -3,6 +3,16 @@ repositories {
     url 'https://download.01.org/crosswalk/releases/crosswalk/android/maven2'
   }
 }
+
+ext.multiarch=true
+
 dependencies {
   compile 'org.xwalk:xwalk_core_library_beta:9.38.208.4'
+}
+
+android {
+    defaultConfig {
+        minSdkVersion 14
+        targetSdkVersion 19
+    }
 }


### PR DESCRIPTION
It is conflict that uses-sdk:minSdkVersion 10 in Cordova project can't samller than version 14 declared in xwalk library.

Gradle overrides the manifest values by defaultConfig:minSdkVersion.

Set ext.multiarch=true to support multiple APKs by default after install the cordova-crosswalk-engine.