### PR TITLE
CB-5059 Add a CookieManager abstraction for Crosswalk.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -26,6 +26,7 @@
         <source-file src="src/android/XWalkCordovaResourceClient.java" target-dir="src/org/apache/cordova/engine/crosswalk" />
         <source-file src="src/android/XWalkCordovaUiClient.java" target-dir="src/org/apache/cordova/engine/crosswalk" />
         <source-file src="src/android/XWalkCordovaView.java" target-dir="src/org/apache/cordova/engine/crosswalk" />
+        <source-file src="src/android/XWalkCordovaCookieManager.java" target-dir="src/org/apache/cordova/engine/crosswalk" />
 
         <framework src="libs/xwalk_core_library/xwalk.gradle" custom="true" type="gradleReference" />
     </platform>

--- a/src/android/XWalkCordovaCookieManager.java
+++ b/src/android/XWalkCordovaCookieManager.java
@@ -1,0 +1,53 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+package org.apache.cordova.engine.crosswalk;
+
+import org.apache.cordova.ICordovaCookieManager;
+import org.xwalk.core.internal.XWalkCookieManager;
+
+class XWalkCordovaCookieManager implements ICordovaCookieManager {
+
+    protected XWalkCookieManager cookieManager = null;
+
+    public XWalkCordovaCookieManager() {
+        cookieManager = new XWalkCookieManager();
+    }
+
+    public void setCookiesEnabled(boolean accept) {
+        cookieManager.setAcceptCookie(accept);
+    }
+
+    public void setCookie(final String url, final String value) {
+        cookieManager.setCookie(url, value);
+    }
+
+    public String getCookie(final String url) {
+        return cookieManager.getCookie(url);
+    }
+
+    public void clearCookies() {
+        cookieManager.removeAllCookie();
+    }
+
+    public void flush() {
+        cookieManager.flushCookieStore();
+    }
+};
+
+

--- a/src/android/XWalkCordovaWebView.java
+++ b/src/android/XWalkCordovaWebView.java
@@ -29,6 +29,7 @@ import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPreferences;
 import org.apache.cordova.CordovaResourceApi;
 import org.apache.cordova.CordovaWebView;
+import org.apache.cordova.ICordovaCookieManager;
 import org.apache.cordova.LOG;
 import org.apache.cordova.NativeToJsMessageQueue;
 import org.apache.cordova.PluginEntry;
@@ -74,6 +75,7 @@ public class XWalkCordovaWebView implements CordovaWebView {
     private PluginManager pluginManager;
     private BroadcastReceiver receiver;
     protected XWalkCordovaView webview;
+    protected XWalkCordovaCookieManager cookieManager;
 
     /** Activities and other important classes **/
     CordovaInterface cordova;
@@ -106,6 +108,8 @@ public class XWalkCordovaWebView implements CordovaWebView {
 
     public XWalkCordovaWebView(XWalkCordovaView webView) {
         this.webview = webView;
+
+        this.cookieManager = new XWalkCordovaCookieManager();
     }
 
     // Use two-phase init so that the control will work with XML layouts.
@@ -390,7 +394,7 @@ public class XWalkCordovaWebView implements CordovaWebView {
     }
 
     @Override
-    public void handleResume(boolean keepRunning, boolean activityResultKeepRunning)
+    public void handleResume(boolean keepRunning)
     {
         webview.evaluateJavascript("try{cordova.fireDocumentEvent('resume');}catch(e){console.log('exception firing resume event from native');};", null);
 
@@ -600,6 +604,11 @@ public class XWalkCordovaWebView implements CordovaWebView {
     @Override
     public CordovaPreferences getPreferences() {
         return preferences;
+    }
+
+    @Override
+    public ICordovaCookieManager getCookieManager() {
+        return cookieManager;
     }
 
     @Override


### PR DESCRIPTION
This allows plugins to access the Crosswalk webview's cookie manager.

/cc @agrieve @infil00p

Requires apache/cordova-android#151