### PR TITLE
Use Crosswalk-11 for Cordova-android 4.0 release

### DIFF
--- a/libs/xwalk_core_library/xwalk.gradle
+++ b/libs/xwalk_core_library/xwalk.gradle
@@ -12,6 +12,6 @@ if (cdvMinSdkVersion == null) {
 }
 
 dependencies {
-  compile 'org.xwalk:xwalk_core_library_beta:10+'
+  compile 'org.xwalk:xwalk_core_library_beta:11+'
 }
 


### PR DESCRIPTION
Crosswalk engine have been tested in mobile-spc and owned functionality tests with Crosswalk-11, and it was our plan to be released.