### PR TITLE
Update to work with cordova-android's commit "a6da46a00e3f4c5bb334077274e4ac4759295fc2"

### DIFF
--- a/src/android/XWalkCordovaResourceClient.java
+++ b/src/android/XWalkCordovaResourceClient.java
@@ -226,6 +226,18 @@ public class XWalkCordovaResourceClient extends XWalkResourceClient {
 
     @Override
     public boolean shouldOverrideUrlLoading(XWalkView view, String url) {
-        return parentEngine.client.shouldOverrideUrlLoading(url);
+        // Give plugins the chance to handle the url
+        if (parentEngine.pluginManager.onOverrideUrlLoading(url)) {
+            return true;
+        } else if (parentEngine.pluginManager.shouldOpenExternalUrl(url)) {
+            parentEngine.getCordovaWebView().showWebPage(url, true, false, null);
+            return true;
+        } else if (!parentEngine.pluginManager.shouldAllowNavigation(url)) {
+            // This blocks iframe navigations as well.
+            LOG.w(TAG, "Blocked (possibly sub-frame) navigation to non-allowed URL: " + url);
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Remove `shouldOverrideUrlLoading` from `CordovaWebViewEngine.Client`.
It's logic that's pretty webview-specific, so it doesn't make sense to  share.